### PR TITLE
Prepping for multi-cluster multi-region clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_cluster" "cluster" {
   }
 
   # Terraform specific config
-  deletion_protection = var.primary_cluster == false ? true : false
+  deletion_protection = var.primary_cluster
 
   # Auth config
   authenticator_groups_config {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_cluster" "cluster" {
   }
 
   # Terraform specific config
-  deletion_protection = var.secondary_region == true ? false : true
+  deletion_protection = var.primary_cluster == false ? true : false
 
   # Auth config
   authenticator_groups_config {

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "google_container_cluster" "cluster" {
   # network config
   network    = var.network
   subnetwork = var.subnetwork
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.secondary_range_pods
     services_secondary_range_name = var.secondary_range_services
@@ -26,6 +27,7 @@ resource "google_container_cluster" "cluster" {
     enable_private_nodes    = true
     enable_private_endpoint = false
     master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+
     master_global_access_config {
       enabled = false
     }
@@ -43,13 +45,13 @@ resource "google_container_cluster" "cluster" {
   }
 
 
-  # Use CloudDNS for routing
+  # Use CloudDNS for routing (Probably sohuld be handled at the network level')
   # Docs: https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#dns-scopes
-  dns_config {
-    cluster_dns                   = "CLOUD_DNS"
-    cluster_dns_scope             = "CLUSTER_SCOPE"
-    additive_vpc_scope_dns_domain = "${var.location}.${var.project_id}"
-  }
+  # dns_config {
+  #   cluster_dns                   = "CLOUD_DNS"
+  #   cluster_dns_scope             = "CLUSTER_SCOPE"
+  #   additive_vpc_scope_dns_domain = "${var.location}.${var.project_id}"
+  # }
 
   addons_config {
     dns_cache_config {

--- a/main.tf
+++ b/main.tf
@@ -1,62 +1,56 @@
-/**
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-locals {
-  # The Google provider is unable to validate certain configurations of
-  # private_cluster_config when enable_private_nodes is false (provider docs)
-  is_private = try(var.private_cluster_config.enable_private_nodes, false)
-  peering = try(
-    google_container_cluster.cluster.private_cluster_config.0.peering_name,
-    null
-  )
-  peering_project_id = (
-    try(var.peering_config.project_id, null) == null
-    ? var.project_id
-    : var.peering_config.project_id
-  )
-}
-
 resource "google_container_cluster" "cluster" {
-  provider                    = google-beta
-  project                     = var.project_id
-  name                        = var.name
-  description                 = var.description
-  location                    = var.location
-  node_locations              = length(var.node_locations) == 0 ? null : var.node_locations
-  min_master_version          = var.min_master_version
-  network                     = var.network
-  subnetwork                  = var.subnetwork
-  logging_service             = var.logging_service
-  monitoring_service          = var.monitoring_service
-  resource_labels             = var.labels
-  default_max_pods_per_node   = var.enable_autopilot ? null : var.default_max_pods_per_node
-  enable_intranode_visibility = var.enable_intranode_visibility
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_tpu                  = var.enable_tpu
-  initial_node_count          = 1
-  remove_default_node_pool    = var.enable_autopilot ? null : true
-  datapath_provider           = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "DATAPATH_PROVIDER_UNSPECIFIED"
-  enable_autopilot            = var.enable_autopilot == true ? true : null
-  deletion_protection         = var.secondary_region == true ? false : true
+  # general config
+  project           = var.project_id
+  name              = var.name
+  description       = var.description
+  location          = var.location
+  resource_labels   = var.labels
+  datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "DATAPATH_PROVIDER_UNSPECIFIED"
 
-  # node_config {}
-  # NOTE: Default node_pool is deleted, so node_config (here) is extranneous.
-  # Specify that node_config as an parameter to gke-nodepool module instead.
+  # node config
+  node_locations           = length(var.node_locations) == 0 ? null : var.node_locations
+  remove_default_node_pool = true
+  initial_node_count       = 1
 
-  # TODO(ludomagno): compute addons map in locals and use a single dynamic block
+  # TODO: maybe delete?
+  default_max_pods_per_node = var.default_max_pods_per_node
+
+  # network config
+  network    = var.network
+  subnetwork = var.subnetwork
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.secondary_range_pods
+    services_secondary_range_name = var.secondary_range_services
+  }
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+    master_global_access_config {
+      enabled = false
+    }
+  }
+
+  # Terraform specific config
+  deletion_protection = var.secondary_region == true ? false : true
+
+  # Auth config
+  authenticator_groups_config {
+    security_group = var.authenticator_groups_config
+  }
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+
+  # Use CloudDNS for routing
+  # Docs: https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#dns-scopes
+  dns_config {
+    cluster_dns                   = "CLOUD_DNS"
+    cluster_dns_scope             = "CLUSTER_SCOPE"
+    additive_vpc_scope_dns_domain = "${var.location}.${var.project_id}"
+  }
+
   addons_config {
     dns_cache_config {
       enabled = var.addons.dns_cache_config
@@ -67,18 +61,11 @@ resource "google_container_cluster" "cluster" {
     horizontal_pod_autoscaling {
       disabled = !var.addons.horizontal_pod_autoscaling
     }
-    dynamic "network_policy_config" {
-      for_each = !var.enable_autopilot ? [""] : []
-      content {
-        disabled = !var.addons.network_policy_config
-      }
+    network_policy_config {
+      disabled = !var.addons.network_policy_config
     }
     cloudrun_config {
       disabled = !var.addons.cloudrun_config
-    }
-    istio_config {
-      disabled = !var.addons.istio_config.enabled
-      auth     = var.addons.istio_config.tls ? "AUTH_MUTUAL_TLS" : "AUTH_NONE"
     }
     gce_persistent_disk_csi_driver_config {
       enabled = var.addons.gce_persistent_disk_csi_driver_config
@@ -88,15 +75,6 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  # TODO(ludomagno): support setting address ranges instead of range names
-  # https://www.terraform.io/docs/providers/google/r/container_cluster.html#cluster_ipv4_cidr_block
-  ip_allocation_policy {
-    cluster_secondary_range_name  = var.secondary_range_pods
-    services_secondary_range_name = var.secondary_range_services
-  }
-
-  # TODO(ludomagno): make optional, and support beta feature
-  # https://www.terraform.io/docs/providers/google/r/container_cluster.html#daily_maintenance_window
   maintenance_policy {
     daily_maintenance_window {
       start_time = var.maintenance_start_time
@@ -128,91 +106,10 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  #the network_policy block is enabled if network_policy_config and network_dataplane_v2 is set to false. Dataplane V2 has built-in network policies.
-  dynamic "network_policy" {
-    for_each = var.addons.network_policy_config ? [""] : []
-    content {
-      enabled  = var.enable_dataplane_v2 ? false : true
-      provider = var.enable_dataplane_v2 ? "PROVIDER_UNSPECIFIED" : "CALICO"
-    }
-  }
-
-  dynamic "private_cluster_config" {
-    for_each = local.is_private ? [var.private_cluster_config] : []
-    iterator = config
-    content {
-      enable_private_nodes    = config.value.enable_private_nodes
-      enable_private_endpoint = config.value.enable_private_endpoint
-      master_ipv4_cidr_block  = config.value.master_ipv4_cidr_block
-      master_global_access_config {
-        enabled = config.value.master_global_access
-      }
-    }
-  }
-
-  # beta features
-
-  dynamic "authenticator_groups_config" {
-    for_each = var.authenticator_security_group == null ? [] : [""]
-    content {
-      security_group = var.authenticator_security_group
-    }
-  }
-
-  dynamic "cluster_autoscaling" {
-    for_each = var.cluster_autoscaling.enabled ? [var.cluster_autoscaling] : []
-    iterator = config
-    content {
-      enabled = true
-      resource_limits {
-        resource_type = "cpu"
-        minimum       = config.value.cpu_min
-        maximum       = config.value.cpu_max
-      }
-      resource_limits {
-        resource_type = "memory"
-        minimum       = config.value.memory_min
-        maximum       = config.value.memory_max
-      }
-      // TODO: support GPUs too
-    }
-  }
-
-  dynamic "database_encryption" {
-    for_each = var.database_encryption.enabled ? [var.database_encryption] : []
-    iterator = config
-    content {
-      state    = config.value.state
-      key_name = config.value.key_name
-    }
-  }
-
-  dynamic "pod_security_policy_config" {
-    for_each = var.pod_security_policy != null ? [""] : []
-    content {
-      enabled = var.pod_security_policy
-    }
-  }
-
   dynamic "release_channel" {
     for_each = var.release_channel != null ? [""] : []
     content {
       channel = var.release_channel
-    }
-  }
-
-  dynamic "resource_usage_export_config" {
-    for_each = (
-      var.resource_usage_export_config.enabled != null
-      &&
-      var.resource_usage_export_config.dataset != null
-      ? [""] : []
-    )
-    content {
-      enable_network_egress_metering = var.resource_usage_export_config.enabled
-      bigquery_destination {
-        dataset_id = var.resource_usage_export_config.dataset
-      }
     }
   }
 
@@ -222,129 +119,4 @@ resource "google_container_cluster" "cluster" {
       enabled = var.vertical_pod_autoscaling
     }
   }
-
-  dynamic "workload_identity_config" {
-    for_each = var.workload_identity && !var.enable_autopilot ? [""] : []
-    content {
-      workload_pool = "${var.project_id}.svc.id.goog"
-    }
-  }
-
-  dynamic "monitoring_config" {
-    for_each = var.monitoring_components != null ? [""] : []
-    content {
-      enable_components = var.monitoring_components
-    }
-  }
-}
-
-resource "google_gke_backup_backup_plan" "backup_plan" {
-  for_each = (
-    var.backup_configs.enable_backup_agent
-    ? var.backup_configs.backup_plans
-    : {}
-  )
-  name     = each.key
-  cluster  = google_container_cluster.cluster.id
-  location = each.value.region
-  project  = var.project_id
-  labels   = each.value.labels
-  retention_policy {
-    backup_delete_lock_days = try(each.value.retention_policy_delete_lock_days)
-    backup_retain_days      = try(each.value.retention_policy_days)
-    locked                  = try(each.value.retention_policy_lock)
-  }
-  backup_schedule {
-    cron_schedule = each.value.schedule
-  }
-  backup_config {
-    include_volume_data = each.value.include_volume_data
-    include_secrets     = each.value.include_secrets
-    dynamic "encryption_key" {
-      for_each = each.value.encryption_key != null ? [""] : []
-      content {
-        gcp_kms_encryption_key = each.value.encryption_key
-      }
-    }
-    all_namespaces = (
-      lookup(each.value, "namespaces", null) != null
-      ||
-      lookup(each.value, "applications", null) != null ? null : true
-    )
-    dynamic "selected_namespaces" {
-      for_each = each.value.namespaces != null ? [""] : []
-      content {
-        namespaces = each.value.namespaces
-      }
-    }
-    dynamic "selected_applications" {
-      for_each = each.value.applications != null ? [""] : []
-      content {
-        dynamic "namespaced_names" {
-          for_each = flatten([for k, vs in each.value.applications : [
-            for v in vs : { namespace = k, name = v }
-          ]])
-          content {
-            namespace = namespaced_names.value.namespace
-            name      = namespaced_names.value.name
-          }
-        }
-      }
-
-    }
-  }
-}
-
-resource "google_compute_network_peering_routes_config" "gke_master" {
-  count                = local.is_private && var.peering_config != null ? 1 : 0
-  project              = local.peering_project_id
-  peering              = local.peering
-  network              = element(reverse(split("/", var.network)), 0)
-  import_custom_routes = var.peering_config.import_routes
-  export_custom_routes = var.peering_config.export_routes
-}
-
-# Enable Anthos Service Mesh Resources
-module "enable_asm" {
-  count  = var.enable_asm ? 1 : 0
-  source = "github.com/dapperlabs-platform/terraform-asm?ref=v1.1"
-
-  project_id                = var.project_id
-  cluster_name              = var.name
-  cluster_location          = var.location
-  enable_cni                = true
-  enable_mesh_feature       = true
-  enable_fleet_registration = true
-  create_cpr                = var.create_cpr
-
-  depends_on = [google_container_cluster.cluster]
-}
-
-# Create GSM secret with Cluster details -> used to register cluster in ArgoCD more easily
-# The cluster ca certificate
-resource "google_secret_manager_secret" "gke_cluster_ca" {
-  secret_id = "gke-cluster-${var.location}-ca-b64" # The name of your secret
-  project   = var.project_id
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "gke_cluster_ca" {
-  secret      = google_secret_manager_secret.gke_cluster_ca.id
-  secret_data = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
-}
-
-# The clusters public endpoint
-resource "google_secret_manager_secret" "gke_cluster_endpoint" {
-  secret_id = "gke-cluster-${var.location}-endpoint" # The name of your secret
-  project   = var.project_id
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "gke_cluster_endpoint" {
-  secret      = google_secret_manager_secret.gke_cluster_endpoint.id
-  secret_data = google_container_cluster.cluster.endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,25 +1,3 @@
-/**
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-output "cluster" {
-  description = "Cluster resource."
-  sensitive   = true
-  value       = google_container_cluster.cluster
-}
-
 output "endpoint" {
   description = "Cluster endpoint."
   value       = google_container_cluster.cluster.endpoint
@@ -30,11 +8,6 @@ output "location" {
   value       = google_container_cluster.cluster.location
 }
 
-output "master_version" {
-  description = "Master version."
-  value       = google_container_cluster.cluster.master_version
-}
-
 output "name" {
   description = "Cluster name."
   value       = google_container_cluster.cluster.name
@@ -42,6 +15,6 @@ output "name" {
 
 output "ca_certificate" {
   description = "Public certificate of the cluster (base64-encoded)."
-  value       = google_container_cluster.cluster.master_auth.0.cluster_ca_certificate
+  value       = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
   sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,7 @@ output "ca_certificate" {
   value       = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
   sensitive   = true
 }
+
+output "gke_private_endpoint" {
+  value = google_container_cluster.cluster.private_cluster_config[0].private_endpoint
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,28 @@
+# Create GSM secret with Cluster details -> used to register cluster in ArgoCD more easily
+# The cluster ca certificate
+resource "google_secret_manager_secret" "gke_cluster_ca" {
+  secret_id = "gke-cluster-${google_container_cluster.cluster.name}-ca-b64" # The name of your secret
+  project   = var.project_id
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "gke_cluster_ca" {
+  secret      = google_secret_manager_secret.gke_cluster_ca.id
+  secret_data = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
+}
+
+# The clusters public endpoint
+resource "google_secret_manager_secret" "gke_cluster_endpoint" {
+  secret_id = "gke-cluster-${google_container_cluster.cluster.name}-endpoint" # The name of your secret
+  project   = var.project_id
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "gke_cluster_endpoint" {
+  secret      = google_secret_manager_secret.gke_cluster_endpoint.id
+  secret_data = google_container_cluster.cluster.endpoint
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,36 +1,21 @@
-/**
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+variable "location" {
+  description = "Cluster zone or region."
+  type        = string
+}
 
 variable "addons" {
   description = "Addons enabled in the cluster (true means enabled)."
   type = object({
-    cloudrun_config            = optional(bool, false)
-    dns_cache_config           = optional(bool, false)
     horizontal_pod_autoscaling = optional(bool, true)
     http_load_balancing        = optional(bool, true)
-    istio_config = optional(object({
-      enabled = optional(bool, false)
-      tls     = optional(bool, false)
-    }), {})
-    network_policy_config                 = optional(bool, true)
-    gce_persistent_disk_csi_driver_config = optional(bool, true)
+    network_policy_config      = optional(bool, true)
     gcp_filestore_csi_driver_config = optional(object({
       enabled = optional(bool, false)
       tier    = optional(string, "standard")
     }), {})
+    cloudrun_config                       = optional(bool, false)
+    dns_cache_config                      = optional(bool, false)
+    gce_persistent_disk_csi_driver_config = optional(bool, true)
   })
   default = {}
 }
@@ -38,45 +23,13 @@ variable "addons" {
 variable "enable_dataplane_v2" {
   description = "Enable Dataplane V2 on the cluster, will disable network_policy addons config"
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "authenticator_security_group" {
+variable "authenticator_groups_config" {
   description = "RBAC security group for Google Groups for GKE, format is gke-security-groups@yourdomain.com."
   type        = string
-  default     = null
-}
-
-variable "cluster_autoscaling" {
-  description = "Enable and configure limits for Node Auto-Provisioning with Cluster Autoscaler."
-  type = object({
-    enabled    = bool
-    cpu_min    = number
-    cpu_max    = number
-    memory_min = number
-    memory_max = number
-  })
-  default = {
-    enabled    = false
-    cpu_min    = 0
-    cpu_max    = 0
-    memory_min = 0
-    memory_max = 0
-  }
-}
-
-variable "database_encryption" {
-  description = "Enable and configure GKE application-layer secrets encryption."
-  type = object({
-    enabled  = bool
-    state    = string
-    key_name = string
-  })
-  default = {
-    enabled  = false
-    state    = "DECRYPTED"
-    key_name = null
-  }
+  default     = "gke-security-groups@dapperlabs.com"
 }
 
 variable "default_max_pods_per_node" {
@@ -91,39 +44,10 @@ variable "description" {
   default     = null
 }
 
-variable "enable_intranode_visibility" {
-  description = "Enable intra-node visibility to make same node pod to pod traffic visible."
-  type        = bool
-  default     = null
-}
-
-variable "enable_shielded_nodes" {
-  description = "Enable Shielded Nodes features on all nodes in this cluster."
-  type        = bool
-  default     = null
-}
-
-variable "enable_tpu" {
-  description = "Enable Cloud TPU resources in this cluster."
-  type        = bool
-  default     = null
-}
-
 variable "labels" {
   description = "Cluster resource labels."
   type        = map(string)
   default     = null
-}
-
-variable "location" {
-  description = "Cluster zone or region."
-  type        = string
-}
-
-variable "logging_service" {
-  description = "Logging service (disable with an empty string)."
-  type        = string
-  default     = "none"
 }
 
 variable "maintenance_start_time" {
@@ -136,18 +60,6 @@ variable "master_authorized_ranges" {
   description = "External Ip address ranges that can access the Kubernetes cluster master through HTTPS."
   type        = map(string)
   default     = {}
-}
-
-variable "min_master_version" {
-  description = "Minimum version of the master, defaults to the version of the most recent official release."
-  type        = string
-  default     = null
-}
-
-variable "monitoring_service" {
-  description = "Monitoring service"
-  type        = string
-  default     = "none"
 }
 
 variable "name" {
@@ -166,31 +78,9 @@ variable "node_locations" {
   default     = []
 }
 
-variable "peering_config" {
-  description = "Configure peering with the master VPC for private clusters."
-  type = object({
-    export_routes = bool
-    import_routes = bool
-    project_id    = string
-  })
-  default = null
-}
-
-variable "pod_security_policy" {
-  description = "Enable the PodSecurityPolicy feature."
-  type        = bool
-  default     = null
-}
-
-variable "private_cluster_config" {
-  description = "Enable and configure private cluster, private nodes must be true if used."
-  type = object({
-    enable_private_nodes    = bool
-    enable_private_endpoint = bool
-    master_ipv4_cidr_block  = string
-    master_global_access    = bool
-  })
-  default = null
+variable "master_ipv4_cidr_block" {
+  description = "The CIDR block for the master nodes"
+  type        = string
 }
 
 variable "project_id" {
@@ -202,18 +92,6 @@ variable "release_channel" {
   description = "Release channel for GKE upgrades."
   type        = string
   default     = null
-}
-
-variable "resource_usage_export_config" {
-  description = "Configure the ResourceUsageExportConfig feature."
-  type = object({
-    enabled = bool
-    dataset = string
-  })
-  default = {
-    enabled = null
-    dataset = null
-  }
 }
 
 variable "secondary_range_pods" {
@@ -237,18 +115,6 @@ variable "vertical_pod_autoscaling" {
   default     = null
 }
 
-variable "workload_identity" {
-  description = "Enable the Workload Identity feature."
-  type        = bool
-  default     = true
-}
-
-variable "enable_autopilot" {
-  description = "Create cluster in autopilot mode. With autopilot there's no need to create node-pools and some features are not supported (e.g. setting default_max_pods_per_node)"
-  type        = bool
-  default     = false
-}
-
 variable "workload_identity_profiles" {
   description = <<EOF
   Namespace-keyed map of GCP Service Account to create K8S Service Accounts for.
@@ -265,58 +131,6 @@ variable "workload_identity_profiles" {
     )
   )
   default = {}
-}
-
-variable "namespaces" {
-  description = "Namespaces to add to the cluster"
-  type        = list(string)
-  default     = []
-}
-
-variable "namespace_protection" {
-  description = "If true - mark namespace with annotation so it can't be deleted see: https://github.com/dapperlabs/kyverno-policies/tree/main/policies/deny-protected-deletes"
-  type        = bool
-  default     = true
-}
-
-variable "enable_asm" {
-  description = "Determines if Anthos Service Mesh should be enabled"
-  type        = bool
-  default     = false
-}
-
-variable "create_cpr" {
-  description = "Determines if the control plane revision should be installed"
-  type        = bool
-  default     = false
-}
-
-variable "backup_configs" {
-  description = "Configuration for Backup for GKE."
-  type = object({
-    enable_backup_agent = optional(bool, false)
-    backup_plans = optional(map(object({
-      region                            = string
-      applications                      = optional(map(list(string)))
-      encryption_key                    = optional(string)
-      include_secrets                   = optional(bool, true)
-      include_volume_data               = optional(bool, true)
-      labels                            = optional(map(string))
-      namespaces                        = optional(list(string))
-      schedule                          = optional(string)
-      retention_policy_days             = optional(number)
-      retention_policy_lock             = optional(bool, false)
-      retention_policy_delete_lock_days = optional(number)
-    })), {})
-  })
-  default  = {}
-  nullable = false
-}
-
-variable "monitoring_components" {
-  description = "List of monitoring components to enable. Supported values include: SYSTEM_COMPONENTS, APISERVER, SCHEDULER, CONTROLLER_MANAGER, STORAGE, HPA, POD, DAEMONSET, DEPLOYMENT, STATEFULSET"
-  type        = list(string)
-  default     = null
 }
 
 variable "secondary_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -133,8 +133,8 @@ variable "workload_identity_profiles" {
   default = {}
 }
 
-variable "secondary_region" {
+variable "primary_cluster" {
   type        = bool
-  description = "Set to true if this is used for a non-default region deployment. This is needed to we don't recreate the workloadIdentityUser IAM binding each time we create a new region."
+  description = "Set to false if this is used for a non-default region deployment. This is needed to we don't recreate the workloadIdentityUser IAM binding each time we create a new region."
   default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 4.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/workload-identity.tf
+++ b/workload-identity.tf
@@ -16,7 +16,7 @@ locals {
 # Allow the KSA to impersonate the GSA by creating IAM policy binding between them
 resource "google_service_account_iam_member" "main" {
   # We dont want to create these IAM bindings for each region, only the original cluster in an environment
-  for_each = var.secondary_region == true ? {} : local.workload_identity_profiles
+  for_each = var.primary_cluster == false ? {} : local.workload_identity_profiles
   depends_on = [
     google_container_cluster.cluster,
   ]


### PR DESCRIPTION
Initial attempt at configuring an updated cluster module to create clusters for the future of Dapper with multi-cluster/multi-region in mind as well as using ClusterDNS and enabling internal routing between our clusters.

This is an opinionated module with preference for our specific needs and has a much reduced config compared to the original clusters module (which was mostly copied from the Google official version). These configurations can change in the future, but the aim of this module is to be more structured towards Dapper's use cases.

#### Some things of note:
- There is NO kubernetes config in this module. It complicates too many things and creates a chicken and egg situation, especially when deleting clusters (which might happen more frequently in multi-region setups)
- These clusters will use GCPs ClusterDNS for routing. It is set up for routing both cluster internal traffic and for traffic that will go between clusters. We are NOT enabling VPC scope on the DNS as this would expose every service within the VPC (which we plan to use a shared VPC across all our products), and Mike is configuring a solution for routing cross-cluster traffic that involves making use of ClusterDNS. But by enabling the vpc_scope option we can enable using Mike's routing solution, while also not natively exposing every service in our VPC.
- Workload identity is enabled by default
- We default to using Dataplane V2 for routing. This enables some eBPF goodness and switches from using Calico to Cilium.
- We are opinionated on the private nature of the clusters and only enable setting the IP range of the master nodes (versus providing option to create a public cluster).