### PR TITLE
Export private IP to GSM

### DIFF
--- a/secrets.tf
+++ b/secrets.tf
@@ -24,5 +24,5 @@ resource "google_secret_manager_secret" "gke_cluster_endpoint" {
 
 resource "google_secret_manager_secret_version" "gke_cluster_endpoint" {
   secret      = google_secret_manager_secret.gke_cluster_endpoint.id
-  secret_data = google_container_cluster.cluster.endpoint
+  secret_data = google_container_cluster.cluster.private_cluster_config[0].private_endpoint
 }


### PR DESCRIPTION
Update GSM secret for the cluster endpoint to use the clusters private endpoint IP

This helps support registering non-primary clusters in ArgoCD by allowing us to insert the private IP address programmatically in the cluster-secrets external secret for all non-primary clusters. We are now using the private IP address as all clusters are being created in the shared VPC, and we can thus use the private IP address.