### PR TITLE
Disabling logging service by default since we use Loki

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "google_container_cluster" "cluster" {
   location          = var.location
   resource_labels   = var.labels
   datapath_provider = var.enable_dataplane_v2 ? "ADVANCED_DATAPATH" : "DATAPATH_PROVIDER_UNSPECIFIED"
+  logging_service   = var.logging_service
 
   # node config
   node_locations           = length(var.node_locations) == 0 ? null : var.node_locations

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "network" {
   type        = string
 }
 
+variable "logging_service" {
+  description = "Logging service for the cluster."
+  type        = string
+  default     = "none"
+}
+
 variable "node_locations" {
   description = "Zones in which the cluster's nodes are located."
   type        = list(string)


### PR DESCRIPTION
Automatically disable the default logging service started by GKE (fluentbit). We use Loki in our clusters and do not need a second log collection service. This was a setting in the previous clusters module that we forgot to carry over.