### PR TITLE
Add GCS FUSE addon

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,9 @@ resource "google_container_cluster" "cluster" {
     gke_backup_agent_config {
       enabled = var.addons.gke_backup_agent_config
     }
+    gcs_fuse_csi_driver_config {
+      enabled = var.addons.gcs_fuse_csi_driver_config
+    }
   }
 
   maintenance_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "addons" {
     dns_cache_config                      = optional(bool, false)
     gce_persistent_disk_csi_driver_config = optional(bool, true)
     gke_backup_agent_config               = optional(bool, false)
+    gcs_fuse_csi_driver_config            = optional(bool, false)
   })
   default = {}
 }


### PR DESCRIPTION
Enables the ability to turn on the gcs fuse addon for GKE clusters